### PR TITLE
Typo fix -- corrects class color unit frame error

### DIFF
--- a/TukuiDps/TukuiDpsParty.lua
+++ b/TukuiDps/TukuiDpsParty.lua
@@ -76,7 +76,7 @@ local function Shared(self, unit)
 	Name:SetShadowOffset(font_shadow and 1 or 0, font_shadow and -1 or 0)
 	Name.frequentUpdates = 0.2
 	if db.classcolor == true then
-		self:Tag(Name, "[Tukui:leader]Tukui:name_short][Tukui:masterlooter][[Tukui:dead][Tukui:afk]")
+		self:Tag(Name, "[Tukui:leader][Tukui:name_short][Tukui:masterlooter][Tukui:dead][Tukui:afk]")
 	else
 		self:Tag(Name, "[Tukui:leader][Tukui:getnamecolor][Tukui:name_short][Tukui:masterlooter][Tukui:dead][Tukui:afk]")
 	end

--- a/TukuiDps/TukuiDpsRaid.lua
+++ b/TukuiDps/TukuiDpsRaid.lua
@@ -78,7 +78,7 @@ local function Shared(self, unit)
 	Name:SetShadowOffset(font_shadow and 1 or 0, font_shadow and -1 or 0)
 	Name.frequentUpdates = 0.2
 	if db.classcolor == true then
-		self:Tag(Name, "[Tukui:leader]Tukui:name_short][Tukui:masterlooter][[Tukui:dead][Tukui:afk]")
+		self:Tag(Name, "[Tukui:leader][Tukui:name_short][Tukui:masterlooter][Tukui:dead][Tukui:afk]")
 	else
 		self:Tag(Name, "[Tukui:leader][Tukui:getnamecolor][Tukui:name_short][Tukui:masterlooter][Tukui:dead][Tukui:afk]")
 	end

--- a/TukuiHeal/TukuiHealParty.lua
+++ b/TukuiHeal/TukuiHealParty.lua
@@ -142,7 +142,7 @@ local function Shared(self, unit)
 	Name:SetShadowOffset(font_shadow and 1 or 0, font_shadow and -1 or 0)
 	Name.frequentUpdates = 0.2
 	if db.classcolor == true then
-		self:Tag(Name, "[Tukui:leader]Tukui:name_short][Tukui:masterlooter][[Tukui:dead][Tukui:afk]")
+		self:Tag(Name, "[Tukui:leader][Tukui:name_short][Tukui:masterlooter][Tukui:dead][Tukui:afk]")
 	else
 		self:Tag(Name, "[Tukui:leader][Tukui:getnamecolor][Tukui:name_short][Tukui:masterlooter][Tukui:dead][Tukui:afk]")
 	end

--- a/TukuiHeal/TukuiHealRaid.lua
+++ b/TukuiHeal/TukuiHealRaid.lua
@@ -123,7 +123,7 @@ local function Shared(self, unit)
 	Name:SetShadowOffset(font_shadow and 1 or 0, font_shadow and -1 or 0)
 	Name.frequentUpdates = 0.2
 	if db.classcolor == true then
-		self:Tag(Name, "[Tukui:leader]Tukui:name_short][Tukui:masterlooter][[Tukui:dead][Tukui:afk]")
+		self:Tag(Name, "[Tukui:leader][Tukui:name_short][Tukui:masterlooter][Tukui:dead][Tukui:afk]")
 	else
 		self:Tag(Name, "[Tukui:leader][Tukui:getnamecolor][Tukui:name_short][Tukui:masterlooter][Tukui:dead][Tukui:afk]")
 	end


### PR DESCRIPTION
Potente found the typo causing the LUA error with class-colored unit frames. You can see his post here: 

http://www.tukui.org/v2/forums/topic.php?id=5858#post-52324

The fix moves a bracket in four files. I made the commit in a completely clean fork so that you could pull it without changing anything else. 

Please reject the request if this isn't helpful; I'm just trying to help save you a few minutes of work. 
